### PR TITLE
Save data from disk to project

### DIFF
--- a/src/SettingsAction.cpp
+++ b/src/SettingsAction.cpp
@@ -7,7 +7,8 @@ SettingsAction::SettingsAction(QObject* parent) :
     _fileOnDiskAction(this, "H5 file on disk"),
     _matrixTypeAction(this, "Matrix storage", "None loaded yet"),
     _numAvailableDimsAction(this, "Variables", "None loaded yet"),
-    _dataDimOneAction(this, "Dim 1", {}, "")
+    _dataDimOneAction(this, "Dim 1", {}, ""),
+    _saveDataToProjectAction(this, "Save data to project", false)
 {
     setText("UMAP Settings");
     setSerializationName("Sparse Matrix Access");
@@ -16,6 +17,7 @@ SettingsAction::SettingsAction(QObject* parent) :
     _matrixTypeAction.setToolTip("Storage type of sparse matrix on disk");
     _numAvailableDimsAction.setToolTip("Number of variables/dimensions/channels in the data");
     _dataDimOneAction.setToolTip("Data dimension 1");
+    _saveDataToProjectAction.setToolTip("Saving the data from disk to a project\nmight yield very large project files and loading times!");
 
     _matrixTypeAction.setDefaultWidgetFlags(gui::StringAction::WidgetFlag::Label);
     _numAvailableDimsAction.setDefaultWidgetFlags(gui::StringAction::WidgetFlag::Label);
@@ -30,6 +32,7 @@ SettingsAction::SettingsAction(QObject* parent) :
     addAction(&_matrixTypeAction);
     addAction(&_numAvailableDimsAction);
     addAction(&_dataDimOneAction);
+    addAction(&_saveDataToProjectAction);
 }
 
 void SettingsAction::fromVariantMap(const QVariantMap& variantMap)
@@ -40,6 +43,7 @@ void SettingsAction::fromVariantMap(const QVariantMap& variantMap)
     _matrixTypeAction.fromParentVariantMap(variantMap);
     _numAvailableDimsAction.fromParentVariantMap(variantMap);
     _dataDimOneAction.fromParentVariantMap(variantMap);
+    _saveDataToProjectAction.fromParentVariantMap(variantMap);
 }
 
 QVariantMap SettingsAction::toVariantMap() const
@@ -50,6 +54,7 @@ QVariantMap SettingsAction::toVariantMap() const
     _matrixTypeAction.insertIntoVariantMap(variantMap);
     _numAvailableDimsAction.insertIntoVariantMap(variantMap);
     _dataDimOneAction.insertIntoVariantMap(variantMap);
+    _saveDataToProjectAction.insertIntoVariantMap(variantMap);
 
     return variantMap;
 }

--- a/src/SettingsAction.cpp
+++ b/src/SettingsAction.cpp
@@ -10,7 +10,7 @@ SettingsAction::SettingsAction(QObject* parent) :
     _dataDimOneAction(this, "Dim 1", {}, "")
 {
     setText("UMAP Settings");
-    setSerializationName("UMAP Settings");
+    setSerializationName("Sparse Matrix Access");
 
     _fileOnDiskAction.setToolTip("H5 file on disk");
     _matrixTypeAction.setToolTip("Storage type of sparse matrix on disk");

--- a/src/SettingsAction.h
+++ b/src/SettingsAction.h
@@ -4,6 +4,9 @@
 #include "actions/OptionAction.h"
 #include "actions/FilePickerAction.h"
 #include "actions/StringAction.h"
+#include "actions/ToggleAction.h"
+
+#include <QString>
 
 // TODO: for now, two dimensions, but goal is to have this user-adjustable
 
@@ -12,12 +15,18 @@ class SettingsAction : public mv::gui::GroupAction
 public:
     SettingsAction(QObject* parent = nullptr);
 
+public: // Getters
+
+    bool getSaveDataToProjectChecked() const { return _saveDataToProjectAction.isChecked(); }
+    QString getFileOnDiskPath() const { return _fileOnDiskAction.getFilePath(); }
+
 public: // Action getters
 
     mv::gui::FilePickerAction& getFileOnDiskAction() { return _fileOnDiskAction; }
     mv::gui::StringAction& getMatrixTypeAction() { return _matrixTypeAction; }
     mv::gui::StringAction& getNumAvailableDimsAction() { return _numAvailableDimsAction; }
     mv::gui::OptionAction& getDataDimOneAction() { return _dataDimOneAction; }
+    mv::gui::ToggleAction& getSaveDataToProjectAction() { return _saveDataToProjectAction; }
 
 public: // Serialization
 
@@ -29,4 +38,5 @@ protected:
     mv::gui::StringAction          _matrixTypeAction;           /** Type of sparse matrix */
     mv::gui::StringAction          _numAvailableDimsAction;     /** Shows number of available dimension */
     mv::gui::OptionAction          _dataDimOneAction;           /** First dimension */
+    mv::gui::ToggleAction          _saveDataToProjectAction;    /** Whether to save the data form disk to the project */
 };

--- a/src/SparseH5AccessPlugin.cpp
+++ b/src/SparseH5AccessPlugin.cpp
@@ -140,8 +140,6 @@ void SparseH5AccessPlugin::fromVariantMap(const QVariantMap& variantMap)
 {
     AnalysisPlugin::fromVariantMap(variantMap);
 
-    mv::util::variantMapMustContain(variantMap, "Settings");
-
     _settingsAction.fromParentVariantMap(variantMap);
 
     if (_settingsAction.getSaveDataToProjectChecked()) {

--- a/src/SparseH5AccessPlugin.cpp
+++ b/src/SparseH5AccessPlugin.cpp
@@ -191,8 +191,9 @@ bool SparseH5AccessPlugin::loadFileFromProject(const QVariantMap& variantMap)
         return false;
     }
 
+    const fs::path mvOpenDir    = mv::projects().getTemporaryDirPath(mv::AbstractProjectManager::TemporaryDirType::Open).toStdString();
     const fs::path projectPath  = mv::projects().getCurrentProject()->getFilePath().toStdString();
-    const fs::path loadPath     = projectPath / fileOnDiskName;
+    const fs::path loadPath     = mvOpenDir / fileOnDiskName;
 
     if (!fs::exists(loadPath)) {
         qDebug() << "SparseH5AccessPlugin::loadFileFromProject: file does not exist in project: " << fileOnDiskName << ", project path: " << projectPath;

--- a/src/SparseH5AccessPlugin.cpp
+++ b/src/SparseH5AccessPlugin.cpp
@@ -178,7 +178,7 @@ bool SparseH5AccessPlugin::saveFileToProject(QVariantMap& variantMap) const
     const bool success = fs::copy_file(fileOnDiskPath, savePath, fs::copy_options::overwrite_existing);
 
     if (success) {
-        variantMap["FileOnDiskName"]    = QVariant::fromValue(fileOnDiskName.string());
+        variantMap["FileOnDiskName"]    = QVariant::fromValue(QString::fromStdString(fileOnDiskName.string()));
         qDebug() << "SparseH5AccessPlugin::saveFileToProject: saved file to project: " << fileOnDiskName << ", load path: " << fileOnDiskPath;
     }
 

--- a/src/SparseH5AccessPlugin.cpp
+++ b/src/SparseH5AccessPlugin.cpp
@@ -118,8 +118,8 @@ void SparseH5AccessPlugin::updateVariable(size_t dim, size_t varIndex) {
     auto varInd = _settingsAction.getDataDimOneAction().getCurrentIndex();
 
     if (varInd < 0) {
-        varInd = 0;
-        qDebug() << "SparseH5AccessPlugin::updateVariable: unexpected behaviour -> varIndex < 0 : " << varInd;
+        qDebug() << "SparseH5AccessPlugin::updateVariable: unexpected behaviour, varIndex < 0 : " << varInd;
+        return;
     }
 
     auto sparseVals = _sparseMatrix->getColumn(varInd);
@@ -179,6 +179,7 @@ bool SparseH5AccessPlugin::saveFileToProject(QVariantMap& variantMap) const
 
     if (success) {
         variantMap["FileOnDiskName"]    = QVariant::fromValue(fileOnDiskName.string());
+        qDebug() << "SparseH5AccessPlugin::saveFileToProject: saved file to project: " << fileOnDiskName << ", load path: " << fileOnDiskPath;
     }
 
     return success;
@@ -196,6 +197,7 @@ bool SparseH5AccessPlugin::loadFileFromProject(const QVariantMap& variantMap)
     const fs::path loadPath     = projectPath / fileOnDiskName;
 
     if (!fs::exists(loadPath)) {
+        qDebug() << "SparseH5AccessPlugin::loadFileFromProject: file does not exist in project: " << fileOnDiskName << ", project path: " << projectPath;
         return false;
     }
 

--- a/src/SparseH5AccessPlugin.h
+++ b/src/SparseH5AccessPlugin.h
@@ -14,6 +14,7 @@
 #include "SettingsAction.h"
 
 #include <QString>
+#include <QVariantMap>
 
 #include <cstdint>
 
@@ -37,6 +38,9 @@ private:
     void updateFile(const QString& filePathQt);
 
     void updateVariable(size_t dim, size_t varIndex);
+
+    bool saveFileToProject(QVariantMap& variantMap) const;
+    bool loadFileFromProject(const QVariantMap& variantMap);
 
 public: // Serialization
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,7 @@
   "dependencies": [
     {
       "name": "hdf5",
+      "default-features": false,
       "features": [ "cpp", "zlib" ] 
     }
   ],


### PR DESCRIPTION
Optionally save (copy to) the sparse matrix file from disk to the project:
- The file is copied to the temporary project folder and then zipped into the `.mv` project file automatically by the core when saving a project
- The file is loaded again from the decompressed temporary project folder created by the core when opening a project

Drive-by:
- Fix settings action name
- Fix hdf5 default features in vcpkg manifest 