### PR TITLE
Enable/Disable dimension selection option while reading from disk

### DIFF
--- a/src/AddRemoveButtonAction.h
+++ b/src/AddRemoveButtonAction.h
@@ -13,12 +13,6 @@ public:
      */
     AddRemoveButtonAction(QObject* parent);
 
-    void changeEnabled(bool add, bool rem)
-    {
-        _addOptionButton.setEnabled(add);
-        _removeOptionButton.setEnabled(rem);
-    }
-
 public: // Action getters
 
     mv::gui::TriggerAction& getAddOptionButton() { return _addOptionButton; }

--- a/src/SparseH5AccessPlugin.cpp
+++ b/src/SparseH5AccessPlugin.cpp
@@ -147,6 +147,16 @@ void SparseH5AccessPlugin::updateOptionsForDim(const int numDim, const QStringLi
     _blockReadingFromFile = false;
 }
 
+void SparseH5AccessPlugin::setSettingsEnabled(bool enablded)
+{
+    _settingsAction.getAddRemoveButtonAction().getAddOptionButton().setEnabled(enablded);
+    _settingsAction.getAddRemoveButtonAction().getRemoveOptionButton().setEnabled(enablded);
+
+    for (auto& dataDimAction : _settingsAction.getDataDimActions()) {
+        dataDimAction->setEnabled(enablded);
+    }
+}
+
 void SparseH5AccessPlugin::init()
 {
     const auto inputData = getInputDataset<Points>();
@@ -169,7 +179,7 @@ void SparseH5AccessPlugin::init()
         _outputPoints = getOutputDataset<Points>();
     }
 
-    _settingsAction.getAddRemoveButtonAction().changeEnabled(false, false);
+    setSettingsEnabled(false);
 
     // Add settings to UI
     _outputPoints->addAction(_settingsAction);
@@ -208,7 +218,7 @@ void SparseH5AccessPlugin::updateFile(const QString& filePathQt)
 
     _settingsAction.getMatrixTypeAction().setString(QString::fromStdString(typeStr));
     _settingsAction.getNumAvailableDimsAction().setString(QString::number(_dimensionNames.size()));
-    _settingsAction.getAddRemoveButtonAction().changeEnabled(true, true);
+    setSettingsEnabled(true);
 
     assert(_settingsAction.getDataDimActions().size() == _numDims);
 
@@ -267,10 +277,10 @@ void SparseH5AccessPlugin::readDataFromDisk() {
         _outputPoints->setData(std::move(result.first), _numDims);
         _outputPoints->setDimensionNames(result.second);
         mv::events().notifyDatasetDataChanged(_outputPoints);
-        _settingsAction.getAddRemoveButtonAction().changeEnabled(true, true);
+        setSettingsEnabled(true);
         };
 
-    _settingsAction.getAddRemoveButtonAction().changeEnabled(false, false);
+    setSettingsEnabled(false);
 
     // Read data asynchronously, then update core data in main thread
     auto future = QtConcurrent::run(readDataAsync).then(this, passDataToCore);

--- a/src/SparseH5AccessPlugin.cpp
+++ b/src/SparseH5AccessPlugin.cpp
@@ -217,6 +217,7 @@ void SparseH5AccessPlugin::updateFile(const QString& filePathQt)
     _sparseMatrix->readFile(filePath);
 
     _dimensionNames = toQStringList(_sparseMatrix->getVarNames());
+    _selectedDimensionIndices = {};
 
     _settingsAction.getMatrixTypeAction().setString(QString::fromStdString(typeStr));
     _settingsAction.getNumAvailableDimsAction().setString(QString::number(_dimensionNames.size()));

--- a/src/SparseH5AccessPlugin.cpp
+++ b/src/SparseH5AccessPlugin.cpp
@@ -149,6 +149,7 @@ void SparseH5AccessPlugin::updateOptionsForDim(const int numDim, const QStringLi
 
 void SparseH5AccessPlugin::setSettingsEnabled(bool enablded)
 {
+    _settingsAction.getFileOnDiskAction().setEnabled(enablded);
     _settingsAction.getAddRemoveButtonAction().getAddOptionButton().setEnabled(enablded);
     _settingsAction.getAddRemoveButtonAction().getRemoveOptionButton().setEnabled(enablded);
 

--- a/src/SparseH5AccessPlugin.cpp
+++ b/src/SparseH5AccessPlugin.cpp
@@ -181,6 +181,7 @@ void SparseH5AccessPlugin::init()
     }
 
     setSettingsEnabled(false);
+    _settingsAction.getFileOnDiskAction().setEnabled(true);   // the filepicker must be enabled at the start
 
     // Add settings to UI
     _outputPoints->addAction(_settingsAction);

--- a/src/SparseH5AccessPlugin.h
+++ b/src/SparseH5AccessPlugin.h
@@ -45,6 +45,8 @@ private:
     bool saveFileToProject(QVariantMap& variantMap) const;
     bool loadFileFromProject(const QVariantMap& variantMap);
 
+    void setSettingsEnabled(bool enablded);
+
 public: // Serialization
 
     Q_INVOKABLE void fromVariantMap(const QVariantMap& variantMap) override;


### PR DESCRIPTION
Accessing an HDF5 file on disk from two threads simultaneously seems to cause issues/crashes.
This PR disables the UI while accessing data on disk.