### PR TITLE
Use `actions/cache` instead of nuget to cache vcpkg dependencies on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,12 @@ jobs:
           conan-password: ${{secrets.LKEB_UPLOAD_USER_PASSWORD}}
           conan-pem: ${{secrets.LKEB_UPLOAD_CERT_CHAIN}}
           rs_ssh_key: ${{ secrets.RULESSUPPORT_DEPLOY_KEY }}
-          
+          sentry-upload: startsWith(github.ref, 'refs/heads/release/')
+          sentry-url: ${{secrets.LKEB_SENTRY_URL }}
+          sentry-org: ${{secrets.LKEB_SENTRY_ORG }}
+          sentry-project: ${{secrets.LKEB_SENTRY_PROJECT }}
+          sentry-auth-token: ${{secrets.LKEB_SENTRY_AUTH_TOKEN }}
+
       - name: Linux build
         if: startsWith(matrix.os, 'ubuntu')
         uses: ManiVaultStudio/github-actions/conan_linuxmac_build@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,8 @@ on:
   workflow_dispatch:
 
 env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-  USERNAME: ManiVaultStudio
-  FEED_URL: https://nuget.pkg.github.com/ManiVaultStudio/index.json
-  VCPKG_BINARY_SOURCES: "clear;nuget,https://nuget.pkg.github.com/ManiVaultStudio/index.json,readwrite"
-
+  VCPKG_COMMIT_SHA: 56bb2411609227288b70117ead2c47585ba07713 # corresponds to tag 2026.04.27
+  
 # for matrix check https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners
 jobs:
   prepare_matrix:
@@ -41,14 +37,14 @@ jobs:
     steps:
       - name: Checkout the source
         if: github.event_name != 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
 
       - name: Checkout the source - pull request
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0
@@ -60,9 +56,9 @@ jobs:
           sudo xcode-select -switch /Applications/Xcode_${{matrix.build-xcode-version}}.app
 
       - name: Setup python version
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Start ssh key agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -75,92 +71,42 @@ jobs:
           key: ${{ secrets.RULESSUPPORT_DEPLOY_KEY }}
           known_hosts: github.com AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
 
-      # Install vcpkg
-      - name: Clone vcpkg
+      - name: Set vcpkg environment (Unix)
+        if: "!startsWith(runner.os, 'Windows')"
         run: |
-          cd ${{ github.workspace }}
-          git clone --branch 2025.07.25 --single-branch https://github.com/microsoft/vcpkg.git
+          echo "VCPKG_DIR=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_ROOT=${{ runner.temp }}/vcpkg" >> $GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $GITHUB_ENV
 
-      # Bootstrap vcpkg
-      - name: Bootstrap vcpkg 
-        if: startsWith(matrix.os, 'windows')
-        shell: pwsh
-        run:  |
-          ${{ github.workspace }}\vcpkg\bootstrap-vcpkg.bat
-          echo "VCPKG_ROOT=${{ github.workspace }}\vcpkg" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "VCPKG_EXE=${{ github.workspace }}\vcpkg\vcpkg.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          echo "VCPKG_LIBRARY_LINKAGE=static" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Bootstrap vcpkg
-        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
-        shell: bash
-        run: |
-          ${{ github.workspace }}/vcpkg/bootstrap-vcpkg.sh 
-          echo "VCPKG_ROOT=${{ github.workspace }}/vcpkg" >> $GITHUB_ENV
-          echo "VCPKG_EXE=${{ github.workspace }}/vcpkg/vcpkg" >> $GITHUB_ENV
-          echo "VCPKG_LIBRARY_LINKAGE=static" >> $GITHUB_ENV
-
-      - name: NuGet dependencies (Linux)
-        if: startsWith(matrix.os, 'ubuntu')
-        shell: bash
-        run:  |
-          sudo apt update && sudo apt install -y mono-complete
-
-      - name: NuGet dependencies (MacOS)
-        if: startsWith(matrix.os, 'macos') && !endsWith(matrix.os, '13')
-        shell: bash
-        run:  |
-          brew update && brew upgrade
-          brew install mono
-
-      # Use cached vcpkg packages if possible
-      - name: Add NuGet sources
-        if: startsWith(matrix.os, 'windows')
+      - name: Set vcpkg environmentg (Windows)
+        if: startsWith(runner.os, 'Windows')
         shell: pwsh
         run: |
-          .$(${{ env.VCPKG_EXE }} fetch nuget) `
-            sources add `
-            -Source "${{ env.FEED_URL }}" `
-            -StorePasswordInClearText `
-            -Name GitHubPackages `
-            -UserName "${{ env.USERNAME }}" `
-            -Password "${{ secrets.GH_VCPKG_PACKAGES }}"
-          .$(${{ env.VCPKG_EXE }} fetch nuget) `
-            setapikey "${{ secrets.GH_VCPKG_PACKAGES }}" `
-            -Source "${{ env.FEED_URL }}"
+          echo "VCPKG_DIR=${{ runner.temp }}/vcpkg" >> $env:GITHUB_ENV
+          echo "VCPKG_ROOT=${{ runner.temp }}/vcpkg" >> $env:GITHUB_ENV
+          echo "VCPKG_BINARY_SOURCES=clear;files,${{ runner.temp }}/vcpkg-cache,readwrite" >> $env:GITHUB_ENV
 
-      - name: Add NuGet sources
-        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
-        shell: bash
-        run: |
-          mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
-            sources add \
-            -Source "${{ env.FEED_URL }}" \
-            -StorePasswordInClearText \
-            -Name GitHubPackages \
-            -UserName "${{ env.USERNAME }}" \
-            -Password "${{ secrets.GH_VCPKG_PACKAGES }}"
-          mono `${{ env.VCPKG_EXE }} fetch nuget | tail -n 1` \
-            setapikey "${{ secrets.GH_VCPKG_PACKAGES }}" \
-            -Source "${{ env.FEED_URL }}"
-
-      # Build the package
-      - name: Windows build
-        if: startsWith(matrix.os, 'windows')
-        uses: ManiVaultStudio/github-actions/conan_windows_build@main
+      - name: Set up binary cache
+        uses: actions/cache@v5
         with:
-          conan-visual-version: ${{matrix.build-cversion}}
-          conan-visual-runtime: ${{matrix.build-runtime}}
-          conan-build-type: ${{matrix.build-config}}
-          conan-user: ${{secrets.LKEB_UPLOAD_USER}}
-          conan-password: ${{secrets.LKEB_UPLOAD_USER_PASSWORD}}
-          conan-pem: ${{secrets.LKEB_UPLOAD_CERT_CHAIN}}
-          rs_ssh_key: ${{ secrets.RULESSUPPORT_DEPLOY_KEY }}
-          sentry-upload: startsWith(github.ref, 'refs/heads/release/')
-          sentry-url: ${{secrets.LKEB_SENTRY_URL }}
-          sentry-org: ${{secrets.LKEB_SENTRY_ORG }}
-          sentry-project: ${{secrets.LKEB_SENTRY_PROJECT }}
-          sentry-auth-token: ${{secrets.LKEB_SENTRY_AUTH_TOKEN }}
+          path: ${{ runner.temp }}/vcpkg-cache
+          key: vcpkg-cache-${{ runner.os }}-${{ matrix.os }}-${{ matrix.build-cversion }}-${{ env.VCPKG_COMMIT_SHA }}-${{ hashFiles('**/vcpkg.json', '**/vcpkg-overlays/**') }}
+          restore-keys: |
+            vcpkg-cache-${{ runner.os }}-${{ matrix.os }}-${{ matrix.build-cversion }}-${{ env.VCPKG_COMMIT_SHA }}
+
+      - name: Clone and checkout vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git --branch master ${{ env.VCPKG_DIR }}
+          git -C ${{ env.VCPKG_DIR }} checkout ${{ env.VCPKG_COMMIT_SHA }}
+
+      - name: Bootstrap vcpkg (Unix)
+        if: "!startsWith(runner.os, 'Windows')"
+        run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.sh -disableMetrics
+
+      - name: Bootstrap vcpkg (Windows)
+        if: startsWith(runner.os, 'Windows')
+        shell: pwsh
+        run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.bat -disableMetrics
 
       - name: Linux build
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  VCPKG_COMMIT_SHA: 56bb2411609227288b70117ead2c47585ba07713 # corresponds to tag 2026.04.27
+  VCPKG_COMMIT_SHA: f3e10653cc27d62a37a3763cd84b38bca07c6075 # corresponds to tag 2026.05.29.1
   
 # for matrix check https://docs.github.com/en/actions/reference/specifications-for-github-hosted-runners
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,19 @@ jobs:
         shell: pwsh
         run: ${{ env.VCPKG_DIR }}/bootstrap-vcpkg.bat -disableMetrics
 
+      # Build the package
+      - name: Windows build
+        if: startsWith(matrix.os, 'windows')
+        uses: ManiVaultStudio/github-actions/conan_windows_build@main
+        with:
+          conan-visual-version: ${{matrix.build-cversion}}
+          conan-visual-runtime: ${{matrix.build-runtime}}
+          conan-build-type: ${{matrix.build-config}}
+          conan-user: ${{secrets.LKEB_UPLOAD_USER}}
+          conan-password: ${{secrets.LKEB_UPLOAD_USER_PASSWORD}}
+          conan-pem: ${{secrets.LKEB_UPLOAD_CERT_CHAIN}}
+          rs_ssh_key: ${{ secrets.RULESSUPPORT_DEPLOY_KEY }}
+          
       - name: Linux build
         if: startsWith(matrix.os, 'ubuntu')
         uses: ManiVaultStudio/github-actions/conan_linuxmac_build@main

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,7 +16,7 @@
       ]
     }
   },
-  "builtin-baseline":"56bb2411609227288b70117ead2c47585ba07713",
+  "builtin-baseline":"f3e10653cc27d62a37a3763cd84b38bca07c6075",
   "overrides": [
     { "name": "hdf5", "version": "2.1.1#1" },
     { "name": "zlib", "version": "1.3.2#1" },

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,7 +5,7 @@
     {
       "name": "hdf5",
       "default-features": false,
-      "features": [ "cpp", "zlib" ] 
+      "features": [ "cpp", "hl", "zlib" ] 
     }
   ],
   "features": {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,10 +16,10 @@
       ]
     }
   },
-  "builtin-baseline":"dd3097e305afa53f7b4312371f62058d2e665320",
+  "builtin-baseline":"56bb2411609227288b70117ead2c47585ba07713",
   "overrides": [
-    { "name": "hdf5", "version": "1.14.6#0" },
-    { "name": "zlib", "version": "1.3.1#0" },
-    { "name": "catch2", "version": "3.9.0#0" }
+    { "name": "hdf5", "version": "2.1.1#1" },
+    { "name": "zlib", "version": "1.3.2#1" },
+    { "name": "catch2", "version": "3.15.0#0" }
     ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -19,7 +19,7 @@
   "builtin-baseline":"f3e10653cc27d62a37a3763cd84b38bca07c6075",
   "overrides": [
     { "name": "hdf5", "version": "2.1.1#1" },
-    { "name": "zlib", "version": "1.3.2#1" },
+    { "name": "zlib", "version": "1.3.2#0" },
     { "name": "catch2", "version": "3.15.0#0" }
     ]
 }


### PR DESCRIPTION
Same as https://github.com/ManiVaultStudio/ExamplePlugins/pull/53